### PR TITLE
Refactor logging to SLF4J and configure rolling file logging

### DIFF
--- a/src/main/java/com/xbuilders/content/vanilla/blockTools/PrefabUtils.java
+++ b/src/main/java/com/xbuilders/content/vanilla/blockTools/PrefabUtils.java
@@ -12,7 +12,6 @@ import org.joml.Vector3i;
 import java.io.*;
 import java.nio.file.Files;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 import static com.xbuilders.engine.common.world.chunk.saving.ChunkSavingLoadingUtils.BLOCK_DATA_MAX_BYTES;
@@ -53,7 +52,7 @@ public class PrefabUtils {
             start.set(start.get() + length);
             return new BlockData(data);
         } catch (IndexOutOfBoundsException e) {
-            LOGGER.log(Level.INFO, "error", e);
+            LOGGER.info("error", e);
             return null; //Catch the error just to be safe
         }
     }
@@ -140,7 +139,7 @@ public class PrefabUtils {
             try {
                 return loadPrefabFromFile(outFile);
             } catch (IOException e) {
-                LOGGER.log(Level.INFO,"error",e);
+                LOGGER.info("error", e);
             }
         }
         return new ChunkVoxels(0, 0, 0);
@@ -170,7 +169,7 @@ public class PrefabUtils {
             try {
                 PrefabUtils.savePrefabToFile(data, file);
             } catch (IOException e) {
-                LOGGER.log(Level.INFO,"error",e);
+                LOGGER.info("error", e);
             }
         });
     }

--- a/src/main/java/com/xbuilders/content/vanilla/blockTools/tools/CopyTool.java
+++ b/src/main/java/com/xbuilders/content/vanilla/blockTools/tools/CopyTool.java
@@ -16,7 +16,6 @@ import org.lwjgl.nuklear.Nuklear;
 import org.lwjgl.system.MemoryStack;
 
 import java.io.IOException;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 import static org.lwjgl.nuklear.Nuklear.nk_layout_row_dynamic;
@@ -42,7 +41,7 @@ public class CopyTool extends BlockTool {
                         try {
                             PasteTool.clipboard = PrefabUtils.loadPrefabFromFile(file);
                         } catch (IOException e) {
-                            LOGGER.log(Level.INFO, "Error", e);
+                            LOGGER.info("Error", e);
                         }
                         System.out.println(PasteTool.clipboard.toString());
                         PasteTool.updateMesh();
@@ -55,7 +54,7 @@ public class CopyTool extends BlockTool {
                         try {
                             PrefabUtils.savePrefabToFile(PasteTool.clipboard, file);
                         } catch (IOException e) {
-                            LOGGER.log(Level.INFO, "Error", e);
+                            LOGGER.info("Error", e);
                         }
                     });
         }

--- a/src/main/java/com/xbuilders/content/vanilla/blockTools/tools/PasteTool.java
+++ b/src/main/java/com/xbuilders/content/vanilla/blockTools/tools/PasteTool.java
@@ -28,7 +28,6 @@ import org.lwjgl.system.MemoryStack;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 import static org.lwjgl.nuklear.Nuklear.nk_layout_row_dynamic;
@@ -54,7 +53,7 @@ public class PasteTool extends BlockTool {
                         try {
                             PasteTool.clipboard = PrefabUtils.loadPrefabFromFile(file);
                         } catch (IOException e) {
-                            LOGGER.log(Level.INFO,"error", e);
+                            LOGGER.info("error", e);
                         }
                         System.out.println(PasteTool.clipboard.toString());
                         PasteTool.updateMesh();

--- a/src/main/java/com/xbuilders/content/vanilla/blocks/blocks/BlockFlag.java
+++ b/src/main/java/com/xbuilders/content/vanilla/blocks/blocks/BlockFlag.java
@@ -10,7 +10,6 @@ import com.xbuilders.engine.common.utils.LoggingUtils;
 import org.joml.Vector3f;
 
 import java.io.IOException;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -39,7 +38,7 @@ public class BlockFlag extends Block {
                 Main.getServer().setBlockData(data, x, y, z);
                 Client.userPlayer.inventory.clear();
             } catch (IOException e) {
-                LOGGER.log(Level.INFO, "Error", e);
+                LOGGER.info("Error", e);
             }
         });
 
@@ -66,7 +65,7 @@ public class BlockFlag extends Block {
                     }
                 }
             } catch (IOException e) {
-                LOGGER.log(Level.INFO, "Error", e);
+                LOGGER.info("Error", e);
             }
         });
     }

--- a/src/main/java/com/xbuilders/content/vanilla/entities/animal/landAndWater/Beaver.java
+++ b/src/main/java/com/xbuilders/content/vanilla/entities/animal/landAndWater/Beaver.java
@@ -18,7 +18,6 @@ import org.joml.Vector3f;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -73,7 +72,7 @@ public class Beaver extends LandAndWaterAnimal {
 
 
             } catch (IOException e) {
-                LOGGER.log(Level.INFO, "Error", e);
+                LOGGER.info("Error", e);
             }
         }
     }

--- a/src/main/java/com/xbuilders/content/vanilla/entities/animal/landAndWater/Turtle.java
+++ b/src/main/java/com/xbuilders/content/vanilla/entities/animal/landAndWater/Turtle.java
@@ -20,7 +20,6 @@ import com.xbuilders.window.utils.texture.TextureUtils;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -75,7 +74,7 @@ public class Turtle extends LandAndWaterAnimal {
                 left_back_fin.loadFromOBJ(resourceLoader.getResourceAsStream("assets/xbuilders/entities/animal\\turtle\\left_back_fin.obj"));
                 right_back_fin.loadFromOBJ(resourceLoader.getResourceAsStream("assets/xbuilders/entities/animal\\turtle\\right_back_fin.obj"));
             } catch (IOException e) {
-                LOGGER.log(Level.INFO, "Error", e);
+                LOGGER.info("Error", e);
             }
         }
 

--- a/src/main/java/com/xbuilders/content/vanilla/entities/animal/quadPedal/QuadPedalLandAnimal.java
+++ b/src/main/java/com/xbuilders/content/vanilla/entities/animal/quadPedal/QuadPedalLandAnimal.java
@@ -20,7 +20,6 @@ import com.xbuilders.window.utils.texture.TextureUtils;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -104,7 +103,7 @@ public abstract class QuadPedalLandAnimal extends LandAnimal {
             this.saddle = ead.saddle;
             this.textures = ead.textures;
         } catch (IOException e) {
-            LOGGER.log(Level.INFO, "Error", e);
+            LOGGER.info("Error", e);
         }
 
         if (hasData) {

--- a/src/main/java/com/xbuilders/content/vanilla/skins/FoxSkin.java
+++ b/src/main/java/com/xbuilders/content/vanilla/skins/FoxSkin.java
@@ -7,7 +7,6 @@ import com.xbuilders.engine.common.resource.ResourceUtils;
 import com.xbuilders.window.utils.texture.TextureUtils;
 
 import java.io.IOException;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -31,7 +30,7 @@ public class FoxSkin extends Skin {
                             ResourceUtils.resourceFile("skins\\fox\\" + texture + ".png"),
                     false).id;
         } catch (IOException e) {
-            LOGGER.log(Level.INFO, "Error", e);
+            LOGGER.info("Error", e);
         }
     }
 

--- a/src/main/java/com/xbuilders/content/vanilla/ui/BarrelUI.java
+++ b/src/main/java/com/xbuilders/content/vanilla/ui/BarrelUI.java
@@ -12,7 +12,6 @@ import org.lwjgl.nuklear.NkRect;
 import org.lwjgl.system.MemoryStack;
 
 import java.io.IOException;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 import static org.lwjgl.nuklear.Nuklear.nk_layout_row_dynamic;
@@ -65,7 +64,7 @@ public class BarrelUI extends ContainerUI {
         try {
             return (barrelStorage.writeToJson());
         } catch (IOException e) {
-            LOGGER.log(Level.INFO, "Error",e);
+            LOGGER.info("Error", e);
             return new byte[0];
         }
     }

--- a/src/main/java/com/xbuilders/content/vanilla/ui/FurnaceUI.java
+++ b/src/main/java/com/xbuilders/content/vanilla/ui/FurnaceUI.java
@@ -18,7 +18,6 @@ import org.lwjgl.system.MemoryStack;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 import static org.lwjgl.nuklear.Nuklear.*;
@@ -122,7 +121,7 @@ public class FurnaceUI extends ContainerUI {
             furnaceData.lastSmeltTime = System.currentTimeMillis();
             return true;
         } catch (Exception e) {
-            LOGGER.log(Level.INFO, "Error saving container data", e);
+            LOGGER.info("Error saving container data", e);
             return false;
         }
     }
@@ -185,7 +184,7 @@ public class FurnaceUI extends ContainerUI {
                 outputGrid.storageSpace.set(0, furnaceData.outputGrid);
 
             } catch (IOException e) {
-                LOGGER.log(Level.INFO, "Error reading container data", e);
+                LOGGER.info("Error reading container data", e);
             }
         } else {
             furnaceData = new FurnaceData();
@@ -205,7 +204,7 @@ public class FurnaceUI extends ContainerUI {
 
             return baos.toByteArray();
         } catch (IOException e) {
-            LOGGER.log(Level.INFO, "Error saving container data", e);
+            LOGGER.info("Error saving container data", e);
             return new byte[0];
         }
     }

--- a/src/main/java/com/xbuilders/engine/client/Client.java
+++ b/src/main/java/com/xbuilders/engine/client/Client.java
@@ -30,8 +30,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static com.xbuilders.Main.LOGGER;
 import static com.xbuilders.Main.versionStringToNumber;
@@ -132,7 +130,7 @@ public class Client {
             });
         } else {
             prog.abort();
-            Logger.getLogger(Client.class.getName()).log(Level.WARNING, "Connection refused", cause);
+            com.xbuilders.Main.LOGGER.warn("Connection refused", cause);
         }
     }
 

--- a/src/main/java/com/xbuilders/engine/client/ClientWindow.java
+++ b/src/main/java/com/xbuilders/engine/client/ClientWindow.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.text.DecimalFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -210,7 +209,7 @@ public class ClientWindow extends NKWindow {
                 saveFile.getParentFile().mkdirs();
                 ImageIO.write(readPixelsOfWindow(), "png", saveFile);
             } catch (IOException e) {
-                LOGGER.log(Level.INFO, "Could not save screenshot", e);
+                LOGGER.info("Could not save screenshot", e);
             }
             screenShotInitialized = false;
             screenshot = false;

--- a/src/main/java/com/xbuilders/engine/client/settings/ClientSettings.java
+++ b/src/main/java/com/xbuilders/engine/client/settings/ClientSettings.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 import static com.xbuilders.engine.client.settings.EngineSettingsUtils.gson;
@@ -82,7 +81,7 @@ public class ClientSettings {
             // Save to JSON
             Files.write(settingsFile.toPath(), gson.toJson(this).getBytes());
         } catch (Exception e) {
-            LOGGER.log(Level.INFO,"error", e);
+            LOGGER.info("error", e);
         }
     }
 

--- a/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/chunk/ChunkShader.java
+++ b/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/chunk/ChunkShader.java
@@ -17,7 +17,6 @@ import org.joml.Vector4f;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 

--- a/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/chunk/meshers/ChunkMeshBundle.java
+++ b/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/chunk/meshers/ChunkMeshBundle.java
@@ -14,7 +14,6 @@ import com.xbuilders.engine.common.world.chunk.Chunk;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 
 import org.lwjgl.system.MemoryStack;
 
@@ -142,7 +141,7 @@ public class ChunkMeshBundle {
 
             }
         } catch (Exception e) {
-            LOGGER.log(Level.INFO, "error", e);
+            LOGGER.info("error", e);
         }
     }
 

--- a/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/chunk/meshers/Chunk_NaiveMesher.java
+++ b/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/chunk/meshers/Chunk_NaiveMesher.java
@@ -18,7 +18,6 @@ import com.xbuilders.engine.common.world.wcc.WCCi;
 import org.joml.Vector3i;
 import org.lwjgl.system.MemoryStack;
 
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 import static com.xbuilders.engine.common.math.MathUtils.positiveMod;
@@ -119,7 +118,7 @@ public class Chunk_NaiveMesher extends ChunkMesher<VertexSet> {
                                             neighbors, neighborData, lightNeghbors, chunk, x, y, z, isUsingGreedyMesher);
                                 }
                             } catch (Exception e) {
-                                LOGGER.log(Level.INFO,"error", e);
+                                LOGGER.info("error", e);
                             }
                         }
                     }

--- a/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/entity/EntityShader.java
+++ b/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/entity/EntityShader.java
@@ -13,7 +13,6 @@ import org.joml.Matrix4f;
 import org.joml.Vector3f;
 
 import java.io.IOException;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -50,7 +49,7 @@ public class EntityShader extends Shader {
                     ResourceUtils.localFile("/res/shaders/entityShader/default.vs"),
                     ResourceUtils.localFile("/res/shaders/entityShader/default.fs"));
         } catch (IOException e) {
-            LOGGER.log(Level.INFO,"error", e);
+            LOGGER.info("error", e);
         }
     }
 

--- a/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/entity/EntityShader_ArrayTexture.java
+++ b/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/entity/EntityShader_ArrayTexture.java
@@ -6,7 +6,6 @@ import com.xbuilders.engine.common.utils.LoggingUtils;
 import com.xbuilders.engine.common.resource.ResourceUtils;
 
 import java.io.IOException;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -28,7 +27,7 @@ public class EntityShader_ArrayTexture extends EntityShader {
                     ResourceUtils.localFile("/res/shaders/entityShader/array texture.vs"),
                     ResourceUtils.localFile("/res/shaders/entityShader/array texture.fs"));
         } catch (IOException e) {
-            LOGGER.log(Level.INFO,"error", e);
+            LOGGER.info("error", e);
         }
     }
 }

--- a/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/entity/block/BlockMeshBundle.java
+++ b/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/entity/block/BlockMeshBundle.java
@@ -13,7 +13,6 @@ import com.xbuilders.engine.common.world.chunk.ChunkVoxels;
 import org.joml.Vector3i;
 import org.lwjgl.system.MemoryStack;
 
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -64,7 +63,7 @@ public class BlockMeshBundle {
                 transBuffer.makeVertexSet();
             }
         } catch (Exception e) {
-            LOGGER.log(Level.INFO,"error", e);
+            LOGGER.info("error", e);
         }
     }
 

--- a/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/entity/block/meshers/Block_NaiveMesher.java
+++ b/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/entity/block/meshers/Block_NaiveMesher.java
@@ -17,7 +17,6 @@ import com.xbuilders.engine.common.world.chunk.ChunkVoxels;
 import org.joml.Vector3i;
 import org.lwjgl.system.MemoryStack;
 
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -110,7 +109,7 @@ public class Block_NaiveMesher extends BlockMesher {
                                 type.constructBlock(transparentBuffers, block, blockData, neighbors, neighborData, light, null, x, y, z, false);
                             }
                         } catch (Exception e) {
-                            LOGGER.log(Level.INFO,"error", e);
+                            LOGGER.info("error", e);
                         }
                     }
                 }

--- a/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/wireframeBox/SolidColorShader.java
+++ b/src/main/java/com/xbuilders/engine/client/visuals/gameScene/rendering/wireframeBox/SolidColorShader.java
@@ -6,8 +6,6 @@ package com.xbuilders.engine.client.visuals.gameScene.rendering.wireframeBox;
 
 import com.xbuilders.window.render.Shader;
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.joml.Vector4f;
 
@@ -43,7 +41,7 @@ public class SolidColorShader extends Shader {
             colorUnifrom = getUniformLocation("color");
             mvpUniform = getUniformLocation("MVP");
         } catch (IOException ex) {
-            Logger.getLogger(SolidColorShader.class.getName()).log(Level.SEVERE, null, ex);
+            com.xbuilders.Main.LOGGER.error("Unhandled exception in SolidColorShader", ex);
         }
     }
 

--- a/src/main/java/com/xbuilders/engine/client/visuals/skybox/SkyBoxShader.java
+++ b/src/main/java/com/xbuilders/engine/client/visuals/skybox/SkyBoxShader.java
@@ -12,7 +12,6 @@ import com.xbuilders.window.render.Shader;
 import org.joml.Matrix4f;
 
 import java.io.IOException;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -34,7 +33,7 @@ import static com.xbuilders.Main.LOGGER;
                     ResourceUtils.localFile("/res/shaders/skybox/sky_shader.vs"),
                     ResourceUtils.localFile("/res/shaders/skybox/sky_shader.fs"));
         } catch (IOException e) {
-            LOGGER.log(Level.INFO,"error", e);
+            LOGGER.info("error", e);
         }
         uniform_cycle_value = getUniformLocation("cycle_value");
         uniform_projViewMatrix = getUniformLocation("projViewMatrix");

--- a/src/main/java/com/xbuilders/engine/client/visuals/topMenu/LoadWorld.java
+++ b/src/main/java/com/xbuilders/engine/client/visuals/topMenu/LoadWorld.java
@@ -20,8 +20,6 @@ import com.xbuilders.window.nuklear.NKUtils;
 import java.io.IOException;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.lwjgl.nuklear.*;
 import org.lwjgl.system.MemoryStack;
@@ -67,7 +65,7 @@ public class LoadWorld implements MenuPage {
                 currentWorld = worlds.get(0);
             }
         } catch (IOException ex) {
-            Logger.getLogger(LoadWorld.class.getName()).log(Level.SEVERE, null, ex);
+            com.xbuilders.Main.LOGGER.error("Unhandled exception in LoadWorld", ex);
         }
     }
 
@@ -145,7 +143,7 @@ public class LoadWorld implements MenuPage {
             try {
                 WorldsHandler.listWorlds(worlds);
             } catch (IOException e) {
-                LOGGER.log(Level.INFO,"error",e);
+                LOGGER.info("error", e);
             }
             currentWorld = null;
 

--- a/src/main/java/com/xbuilders/engine/client/visuals/topMenu/TopMenu.java
+++ b/src/main/java/com/xbuilders/engine/client/visuals/topMenu/TopMenu.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static org.lwjgl.nuklear.Nuklear.*;
 import static org.lwjgl.opengl.GL11C.*;
@@ -175,7 +173,7 @@ public class TopMenu {
                 localClient.loadWorld(worlds.get(0), null);
             }
         } catch (IOException ex) {
-            Logger.getLogger(TopMenu.class.getName()).log(Level.SEVERE, null, ex);
+            com.xbuilders.Main.LOGGER.error("Unhandled exception in TopMenu", ex);
         }
 
     }

--- a/src/main/java/com/xbuilders/engine/common/network/fake/FakeChannel.java
+++ b/src/main/java/com/xbuilders/engine/common/network/fake/FakeChannel.java
@@ -13,8 +13,6 @@ import java.util.HashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class FakeChannel extends ChannelBase {
     private final FakeServer server;
@@ -62,11 +60,11 @@ public class FakeChannel extends ChannelBase {
                             client.receive(packet);
                         }
                     } catch (Exception e) {
-                        Main.LOGGER.log(Level.WARNING, "Failed to receive fake packet", e);
+                        Main.LOGGER.warn("Failed to receive fake packet", e);
                     }
                 }
             } catch (InterruptedException ignored) {
-                Logger.getLogger(FakeChannel.class.getName()).log(Level.SEVERE, "FakeChannel interrupted!", ignored);
+                com.xbuilders.Main.LOGGER.error("FakeChannel interrupted!", ignored);
             }
         });
         processingThread.start();

--- a/src/main/java/com/xbuilders/engine/common/packets/ChunkDataPacket.java
+++ b/src/main/java/com/xbuilders/engine/common/packets/ChunkDataPacket.java
@@ -16,7 +16,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
 
 /**
  * This packet is all about sending chunks to the client
@@ -100,7 +99,7 @@ public class ChunkDataPacket extends Packet {
             chunk.markAsModified();
             chunk.progressGenState(ClientChunk.GEN_VOXELS_GENERATED);
         } catch (IOException | ChunkReadingException e) {
-            Main.LOGGER.log(Level.WARNING, "Failed to read chunk data", e);
+            Main.LOGGER.warn("Failed to read chunk data", e);
         }
     }
 

--- a/src/main/java/com/xbuilders/engine/common/players/localPlayer/LocalPlayer.java
+++ b/src/main/java/com/xbuilders/engine/common/players/localPlayer/LocalPlayer.java
@@ -37,7 +37,6 @@ import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 import static com.xbuilders.content.vanilla.Blocks.BLOCK_AIR;
@@ -433,7 +432,7 @@ public class LocalPlayer extends Player {
 
                 selectedItemIndex = 0;
             } catch (Exception e) {
-                LOGGER.log(Level.INFO,"error", e);
+                LOGGER.info("error", e);
             }
         }
     }

--- a/src/main/java/com/xbuilders/engine/common/players/localPlayer/camera/Camera.java
+++ b/src/main/java/com/xbuilders/engine/common/players/localPlayer/camera/Camera.java
@@ -16,7 +16,6 @@ import com.xbuilders.engine.common.world.chunk.BlockData;
 import java.awt.*;
 import java.lang.Math;
 import java.nio.IntBuffer;
-import java.util.logging.Level;
 
 import org.joml.*;
 import org.lwjgl.glfw.GLFW;
@@ -123,7 +122,7 @@ public class Camera {
         try {
             robot = new Robot();
         } catch (AWTException e) {
-            LOGGER.log(Level.INFO,"error", e);
+            LOGGER.info("error", e);
         }
 
         target = new Vector3f();

--- a/src/main/java/com/xbuilders/engine/common/resource/ResourceLoader.java
+++ b/src/main/java/com/xbuilders/engine/common/resource/ResourceLoader.java
@@ -8,7 +8,6 @@ import java.io.*;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 

--- a/src/main/java/com/xbuilders/engine/common/world/World.java
+++ b/src/main/java/com/xbuilders/engine/common/world/World.java
@@ -16,7 +16,6 @@ import org.joml.Vector3i;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 import static com.xbuilders.Main.game;
@@ -288,7 +287,7 @@ public abstract class World<T extends Chunk> {
 //        try {
 //            getData().save();
 //        } catch (IOException ex) {
-//            LOGGER.log(Level.INFO, "World \"" + getData().getName() + "\" could not be saved", ex);
+//            LOGGER.info( "World \"" + getData().getName() + "\" could not be saved", ex);
 //        }
     }
 
@@ -307,7 +306,7 @@ public abstract class World<T extends Chunk> {
         this.data = data;
         this.terrain = game.getTerrainFromInfo(data);
         if (terrain == null) {
-            LOGGER.log(Level.SEVERE, "Terrain not found");
+            LOGGER.error("Terrain not found");
         } else System.out.println("Terrain: " + this.terrain);
     }
 }

--- a/src/main/java/com/xbuilders/engine/common/world/WorldsHandler.java
+++ b/src/main/java/com/xbuilders/engine/common/world/WorldsHandler.java
@@ -9,7 +9,6 @@ import com.xbuilders.engine.common.resource.ResourceUtils;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -52,7 +51,7 @@ public class WorldsHandler {
                     info.load(subDir);
                     worlds.add(info);
                 } catch (IOException ex) {
-                    LOGGER.log(Level.WARNING, "World \"" + formatWorldName(subDir.getName()) + "\" could not be loaded", ex);
+                    LOGGER.warn( "World \"" + formatWorldName(subDir.getName()) + "\" could not be loaded", ex);
                 }
             }
         }

--- a/src/main/java/com/xbuilders/engine/common/world/chunk/Chunk.java
+++ b/src/main/java/com/xbuilders/engine/common/world/chunk/Chunk.java
@@ -9,8 +9,6 @@ import org.joml.Vector3i;
 
 import java.util.Objects;
 import java.util.concurrent.Future;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class Chunk {
 
@@ -140,7 +138,7 @@ public class Chunk {
         try {
             voxels.dispose();
         } catch (Exception ex) {
-            Logger.getLogger(Chunk.class.getName()).log(Level.SEVERE, null, ex);
+            com.xbuilders.Main.LOGGER.error("Unhandled exception in Chunk", ex);
         }
     }
 
@@ -181,6 +179,6 @@ public class Chunk {
     }
 
     public void log(String str) {
-        Main.LOGGER.log(Level.INFO, "CHUNK " + position.x + " " + position.y + " " + position.z + " \t" + str);
+        Main.LOGGER.info( "CHUNK " + position.x + " " + position.y + " " + position.z + " \t" + str);
     }
 }

--- a/src/main/java/com/xbuilders/engine/common/world/chunk/saving/ChunkFile_V1.java
+++ b/src/main/java/com/xbuilders/engine/common/world/chunk/saving/ChunkFile_V1.java
@@ -8,7 +8,6 @@ import org.joml.Vector3f;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 import static com.xbuilders.engine.common.utils.bytes.ByteUtils.bytesToInt;
@@ -106,7 +105,7 @@ public class ChunkFile_V1 {
             start.set(start.get() + length);
             return new BlockData(data);
         } catch (IndexOutOfBoundsException e) {
-            LOGGER.log(Level.INFO, "Error", e);
+            LOGGER.info("Error", e);
             return null; //Catch the error just to be safe
         }
     }

--- a/src/main/java/com/xbuilders/engine/common/world/chunk/saving/ChunkSavingLoadingUtils.java
+++ b/src/main/java/com/xbuilders/engine/common/world/chunk/saving/ChunkSavingLoadingUtils.java
@@ -14,7 +14,6 @@ import java.io.*;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -70,7 +69,7 @@ public class ChunkSavingLoadingUtils {
         try (FileOutputStream fos = new FileOutputStream(f)) {
             return writeChunk(chunk, fos);
         } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "Failed to write chunk to file", e);
+            LOGGER.error("Failed to write chunk to file", e);
             return false;
         }
     }
@@ -129,7 +128,7 @@ public class ChunkSavingLoadingUtils {
             out.close();
 
         } catch (Exception e) {
-            LOGGER.log(Level.INFO, "Error", e);
+            LOGGER.info("Error", e);
             return false;
         }
         // }
@@ -227,7 +226,7 @@ public class ChunkSavingLoadingUtils {
             File backupFile = backupFile(f);
 
             //Create the log
-            LOGGER.log(Level.WARNING, "Error occurred reading chunk: " + chunk +
+            LOGGER.warn( "Error occurred reading chunk: " + chunk +
                     " \nBackup File Exists: " + backupFile.exists() +
                     (hasDetectedIfFileWasReadCorrectly.get() ? " \nFile Read Correctly: " + fileReadCorrectly : ""), ex);
 
@@ -244,7 +243,7 @@ public class ChunkSavingLoadingUtils {
             File backupFile = backupFile(f);
 
             //Create the log
-            LOGGER.log(Level.WARNING, "Error occurred reading chunk: " + chunk +
+            LOGGER.warn( "Error occurred reading chunk: " + chunk +
                     " \nBackup File Exists: " + backupFile.exists() +
                     (hasDetectedIfFileWasReadCorrectly.get() ? " \nFile Read Correctly: " + fileReadCorrectly : ""), ex);
 

--- a/src/main/java/com/xbuilders/engine/server/ItemUtils.java
+++ b/src/main/java/com/xbuilders/engine/server/ItemUtils.java
@@ -14,7 +14,6 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -39,7 +38,7 @@ public class ItemUtils {
             }
             return allItems;
         } catch (IOException e) {
-            LOGGER.log(Level.INFO, "error", e);
+            LOGGER.info("error", e);
         }
         return new ArrayList<>();
     }
@@ -63,7 +62,7 @@ public class ItemUtils {
             }
             return allItems;
         } catch (IOException e) {
-            LOGGER.log(Level.INFO, "error", e);
+            LOGGER.info("error", e);
         }
         return new ArrayList<>();
     }
@@ -100,7 +99,7 @@ public class ItemUtils {
 
             return allBlocks;
         } catch (IOException e) {
-            LOGGER.log(Level.INFO, "error", e);
+            LOGGER.info("error", e);
         }
         return new ArrayList<>();
     }
@@ -125,7 +124,7 @@ public class ItemUtils {
             }
             return allItems;
         } catch (IOException e) {
-            LOGGER.log(Level.INFO, "error", e);
+            LOGGER.info("error", e);
         }
         return new ArrayList<>();
     }

--- a/src/main/java/com/xbuilders/engine/server/Server.java
+++ b/src/main/java/com/xbuilders/engine/server/Server.java
@@ -37,7 +37,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 import static com.xbuilders.Main.versionStringToNumber;

--- a/src/main/java/com/xbuilders/engine/server/block/construction/BlockTypeModel/ObjToBlockModel.java
+++ b/src/main/java/com/xbuilders/engine/server/block/construction/BlockTypeModel/ObjToBlockModel.java
@@ -15,7 +15,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -176,7 +175,7 @@ public class ObjToBlockModel {
             Files.writeString(outputFile.toPath(), str);
             System.out.println("\tSaved to: " + outputFile.toString());
         } catch (Exception ex) {
-            LOGGER.log(Level.INFO, "Error", ex);
+            LOGGER.info("Error", ex);
         }
     }
 

--- a/src/main/java/com/xbuilders/engine/server/entity/ItemDrop.java
+++ b/src/main/java/com/xbuilders/engine/server/entity/ItemDrop.java
@@ -17,7 +17,6 @@ import com.xbuilders.engine.common.math.MathUtils;
 import org.joml.Vector3f;
 
 import java.io.IOException;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -76,7 +75,7 @@ public class ItemDrop extends Entity {
                 }
                 if (definitionData.stack == null) destroy();
             } catch (Exception e) {
-                LOGGER.log(Level.INFO,"error",e);
+                LOGGER.info("error", e);
             }
         }
     }

--- a/src/main/java/com/xbuilders/engine/server/item/ItemRegistry.java
+++ b/src/main/java/com/xbuilders/engine/server/item/ItemRegistry.java
@@ -13,7 +13,6 @@ import com.xbuilders.engine.common.resource.ResourceUtils;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.logging.Level;
 
 import static com.xbuilders.Main.LOGGER;
 
@@ -81,7 +80,7 @@ public class ItemRegistry {
                 item.init(blockMap, entityMap, blockAliasToIDMap, entityAliasToIDMap,
                         textures, ResourceUtils.BLOCK_ICON_DIR, defaultIcon);
             } catch (Exception e) {
-                LOGGER.log(Level.INFO, "An error occured setting up item \"" + item.toString() + "\"", e);
+                LOGGER.info( "An error occured setting up item \"" + item.toString() + "\"", e);
             }
         }
     }

--- a/src/main/java/com/xbuilders/engine/server/item/blockIconRendering/BlockIconRenderer.java
+++ b/src/main/java/com/xbuilders/engine/server/item/blockIconRendering/BlockIconRenderer.java
@@ -21,8 +21,6 @@ import com.xbuilders.window.utils.texture.TextureUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
@@ -150,7 +148,7 @@ public class BlockIconRenderer {
                 GLFW.glfwDestroyWindow(window1);
                 lock.unlock();
             } catch (Exception ex) {
-                Logger.getLogger(BlockIconRenderer.class.getName()).log(Level.SEVERE, null, ex);
+                com.xbuilders.Main.LOGGER.error("Unhandled exception in BlockIconRenderer", ex);
             }
         });
     }

--- a/src/main/java/com/xbuilders/window/NKWindow.java
+++ b/src/main/java/com/xbuilders/window/NKWindow.java
@@ -14,8 +14,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.util.Objects;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.nuklear.Nuklear.*;
@@ -69,7 +67,7 @@ public abstract class NKWindow extends GLFWWindow {
         try {
             setupContext();
         } catch (IOException ex) {
-            Logger.getLogger(NKWindow.class.getName()).log(Level.SEVERE, null, ex);
+            com.xbuilders.Main.LOGGER.error("Unhandled exception in NKWindow", ex);
         }
     }
 

--- a/src/main/java/com/xbuilders/window/nuklear/NKFontUtils.java
+++ b/src/main/java/com/xbuilders/window/nuklear/NKFontUtils.java
@@ -16,7 +16,6 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
-import java.util.logging.Level;
 
 import static com.xbuilders.window.utils.IOUtil.ioResourceToByteBuffer;
 import static org.lwjgl.nuklear.Nuklear.NK_UTF_INVALID;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_DIR" value="logs"/>
+    <property name="LOG_FILE" value="${LOG_DIR}/xbuilders.log"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE}</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/xbuilders.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
### Motivation
- Replace ad-hoc uses of `java.util.logging`/print statements with SLF4J usage and centralize logging behavior. 
- Ensure application logs are written to a file with rotation so diagnostics persist across runs. 

### Description
- Replaced many `Logger.getLogger(...).log(Level.*, ...)` and `LOGGER.log(...)` usages with SLF4J-style calls (`info`, `warn`, `error`) and switched to the existing `Main.LOGGER` where appropriate across the codebase (multiple client/server/common modules). 
- Removed lingering `java.util.logging` imports and adjusted several exception paths to log exceptions via SLF4J (e.g. `com.xbuilders.Main.LOGGER.error(...)`, `LOGGER.warn(...)`, `LOGGER.info(...)`). 
- Added `src/main/resources/logback.xml` to configure Logback with a console appender and a rolling file appender that writes to `logs/xbuilders.log` using size+time-based rotation (`10MB` max per file, daily rollover, `maxHistory=14`, total cap `1GB`). 
- Applied automated replacements and committed changes across ~43 files; preserved existing logger instance usage (`Main.LOGGER`) and avoided introducing new logger fields unnecessarily. 

### Testing
- Built the project successfully with `mvn -q -DskipTests compile` (succeeded). 
- Constructed and ran a small SLF4J probe against the project classpath to emit `FILE_LOG_PROBE_MESSAGE` and verified the message appeared in `logs/xbuilders.log` (file created and probe message found). 
- Verified runtime classpath generation with `mvn -q -DincludeScope=runtime dependency:build-classpath` and scanned sources to ensure `java.util.logging` imports and `Logger.getLogger` usages were removed (grep checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a226e959688324adee38badc593031)